### PR TITLE
Enhance Ubiquiti dependency mapping, display version.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,8 @@ grep -qxF '* hard nofile 65535' /etc/systemd/system.conf || echo "* hard nofile 
 ## Clone the repo and run initial setup
 (cd /usr/share; rm -rf sonar_poller; mkdir sonar_poller; cd sonar_poller; git clone https://github.com/SonarSoftwareInc/poller.git .;)
 
-## Write version
+## Write version and prevent potential dubious ownership error
+git config --global --add safe.directory /usr/share/sonar_poller
 (cd /usr/share/sonar_poller; git describe --tags > version;)
 
 ## Setup permissions

--- a/src/DeviceMappers/Ubiquiti/AirMaxAccessPoint.php
+++ b/src/DeviceMappers/Ubiquiti/AirMaxAccessPoint.php
@@ -24,7 +24,8 @@ class AirMaxAccessPoint extends BaseDeviceMapper
     {
         $interfaces = $snmpResult->getInterfaces();
         foreach ($interfaces as $key => $deviceInterface) {
-            if (strpos($deviceInterface->getName(),"wifi") !== false) {
+            if ((strpos($deviceInterface->getName(), "wifi") !== false)
+               || (strpos($deviceInterface->getName(), "ath0") !== false)) {
                 $existingMacs = $interfaces[$key]->getConnectedLayer1Macs();
 
                 try {


### PR DESCRIPTION
The interface ath0 on some devices is exposed over the wifi tagged interfaces.  This was preventing the Ubiquiti devices from gathering the dependency information and feeding it back into Sonar.  

Setup script was adjusted so that changes to the file permissions on the poller do not cause git to generate the error:
    ` fatal: detected dubious ownership in repository at '/usr/share/sonar_poller'`