### PR TITLE
AB#30556 - Fix empty or "Not Associated" strings from causing issue

### DIFF
--- a/src/DeviceMappers/Cambium/EPMPAccessPoint.php
+++ b/src/DeviceMappers/Cambium/EPMPAccessPoint.php
@@ -26,7 +26,9 @@ class EPMPAccessPoint extends BaseDeviceMapper
                 try {
                     $result = $this->walk("1.3.6.1.4.1.17713.21.1.2.30.1.1");
                     foreach ($result->getAll() as $datum) {
-                        $existingMacs[] = Formatter::formatMac($datum);
+                        if (Formatter::validateMac($datum)) {
+                            $existingMacs[] = Formatter::formatMac($datum);
+                        }
                     }
                 } catch (Throwable $e) {
                     $log = new Log();
@@ -36,9 +38,13 @@ class EPMPAccessPoint extends BaseDeviceMapper
                 }
 
                 //If this is a station (slave end of a backhaul, for example) we need to query this OID as well
+                // However, it can return either an empty string or "Not Associated" which need to be handled.
                 try {
                     $result = $this->device->getSnmpClient()->get('1.3.6.1.4.1.17713.21.1.2.19.0');
-                    $existingMacs[] = Formatter::formatMac($result->get('1.3.6.1.4.1.17713.21.1.2.19.0'));
+                    $resultMac = $result->get('1.3.6.1.4.1.17713.21.1.2.19.0');
+                    if (Formatter::validateMac($resultMac)) {
+                        $existingMacs[] = Formatter::formatMac($resultMac);
+                    }
                 } catch (Throwable $e) {
                     $log = new Log();
                     $log->exception($e, [


### PR DESCRIPTION
The ePMP device could return either an empty string or "Not Associated" in certain instances which was causing the poller to crash.  These are indeed valid values to be returned from the MIB and need to be handled without causing a crash.  In addition to addressing the OID referenced in this card the MIB was also reviewed and a second OID was identified as being in use that could also return those values.  This has been addressed as well.

This addresses https://github.com/SonarSoftwareInc/poller/issues/21

