### PR TITLE
AB#32152 - Initial Release

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -7,14 +7,14 @@ if [[ -f /etc/os-release ]]; then
   . /etc/os-release
   if [[ "$NAME" == "Ubuntu" && "$VERSION_ID" == "20.04" ]]; then
     echo "Currently running maintenance release for Ubuntu 20.04, please consider upgrading to Ubuntu 24.04 for updates!"
-    GIT_BRANCH="origin/ubuntu20_04"
+    GIT_BRANCH="origin/legacy"
   elif [[ "$NAME" != "Ubuntu" || "$VERSION_ID" != "24.04" ]]; then
     echo "WARNING: Unsupported OS or version. This script supports only Ubuntu 20.04 and 24.04."
-    GIT_BRANCH="origin/ubuntu20_04"
+    GIT_BRANCH="origin/legacy"
   fi
 else
   echo "WARNING: /etc/os-release not found.  Unsupported and proceeding with OLD branch."
-  GIT_BRANCH="origin/ubuntu20_04"
+  GIT_BRANCH="origin/legacy"
 fi
 
 # Switch to the appropriate branch and pull updates

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,7 +1,22 @@
-(cd /usr/share/sonar_poller; git reset --hard origin/master; git pull;)
+#!/bin/bash
 
-(cd /usr/share/sonar_poller; git describe --tags > version;)
-(cd /usr/share/sonar_poller; composer install;)
+GIT_BRANCH="origin/master" # Default branch
+
+# Detect Ubuntu version
+UBUNTU_VERSION=$(lsb_release -rs)
+if [[ "$UBUNTU_VERSION" == "20.04" ]]; then
+  echo "Currently running maintenance release for Ubuntu 20.04, please consider upgrading to Ubuntu 24.04 for updates!"
+  GIT_BRANCH="origin/ubuntu20_04"
+fi
+
+# Switch to the appropriate branch and pull updates
+cd /usr/share/sonar_poller
+git reset --hard "$GIT_BRANCH"
+git pull "$GIT_BRANCH"
+
+# Update version and dependencies
+git describe --tags > version
+sudo -u www-data composer install
 
 chown -R www-data:www-data /usr/share/sonar_poller/www
 chown -R www-data:www-data /usr/share/sonar_poller/ssl

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -3,9 +3,17 @@
 GIT_BRANCH="origin/master" # Default branch
 
 # Detect Ubuntu version
-UBUNTU_VERSION=$(lsb_release -rs)
-if [[ "$UBUNTU_VERSION" == "20.04" ]]; then
-  echo "Currently running maintenance release for Ubuntu 20.04, please consider upgrading to Ubuntu 24.04 for updates!"
+if [[ -f /etc/os-release ]]; then
+  . /etc/os-release
+  if [[ "$NAME" == "Ubuntu" && "$VERSION_ID" == "20.04" ]]; then
+    echo "Currently running maintenance release for Ubuntu 20.04, please consider upgrading to Ubuntu 24.04 for updates!"
+    GIT_BRANCH="origin/ubuntu20_04"
+  elif [[ "$NAME" != "Ubuntu" || "$VERSION_ID" != "24.04" ]]; then
+    echo "WARNING: Unsupported OS or version. This script supports only Ubuntu 20.04 and 24.04."
+    GIT_BRANCH="origin/ubuntu20_04"
+  fi
+else
+  echo "WARNING: /etc/os-release not found.  Unsupported and proceeding with OLD branch."
   GIT_BRANCH="origin/ubuntu20_04"
 fi
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -12,7 +12,7 @@ fi
 # Switch to the appropriate branch and pull updates
 cd /usr/share/sonar_poller
 git reset --hard "$GIT_BRANCH"
-git pull "$GIT_BRANCH"
+git pull
 
 # Update version and dependencies
 git describe --tags > version


### PR DESCRIPTION
We need to take a two step approach to getting this up to date for Ubuntu 24.04 (skipping 22.04).  This is the first step where we will update the upgrade.sh script to know about the support for 20.04 AND 24.04!   

Here we will want to merge this into master.  Once that is complete we will want to create an identical branch to master named legacy.  This will be where the "maintenance" version lives and will likely not receive any updates.

After that we need to tag a new release 2.0.16 - Pre support for Ubuntu 24.04.

By doing that we will get all of the current installations to pull this new script ahead of making Ubuntu 24.04 the supported version in master.